### PR TITLE
Add begin/rescue with retry to try to reconnect to db

### DIFF
--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -34,22 +34,55 @@ module Octopus
       :prepared_statements, :transaction_state, :create_table, to: :select_connection
 
     def execute(sql, name = nil)
-      conn = select_connection
-      clean_connection_proxy if should_clean_connection_proxy?('execute')
-      conn.execute(sql, name)
+      begin
+        retries ||= 0
+        conn = select_connection
+        clean_connection_proxy if should_clean_connection_proxy?('execute')
+        conn.execute(sql, name)
+      rescue ActiveRecord::StatementInvalid => e
+        if connection_bad(e.message)
+          Octopus.logger.error "Octopus.logger.error execute: #{e.message}"
+          conn.verify!
+          retry if (retries += 1) < 3
+        else
+          raise e
+        end
+      end
     end
 
     def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [])
-      conn = select_connection
-      clean_connection_proxy if should_clean_connection_proxy?('insert')
-      conn.insert(arel, name, pk, id_value, sequence_name, binds)
+      begin
+        retries ||= 0
+        conn = select_connection
+        clean_connection_proxy if should_clean_connection_proxy?('insert')
+        conn.insert(arel, name, pk, id_value, sequence_name, binds)
+      rescue ActiveRecord::StatementInvalid => e
+        if connection_bad(e.message)
+          Octopus.logger.error "Octopus.logger.error insert: #{e.message}"
+          conn.verify!
+          retry if (retries += 1) < 3
+        else
+          raise e
+        end
+      end
     end
 
     def update(arel, name = nil, binds = [])
-      conn = select_connection
-      # Call the legacy should_clean_connection_proxy? method here, emulating an insert.
-      clean_connection_proxy if should_clean_connection_proxy?('insert')
-      conn.update(arel, name, binds)
+      begin
+        retries ||= 0
+        conn = select_connection
+        # Call the legacy should_clean_connection_proxy? method here, emulating an insert.
+        clean_connection_proxy if should_clean_connection_proxy?('insert')
+        conn.update(arel, name, binds)
+      rescue ActiveRecord::StatementInvalid => e
+        if connection_bad(e.message)
+          Octopus.logger.error "Octopus.logger.error update: #{e.message}"
+          conn.verify!
+          retry if (retries += 1) < 3
+        else
+          raise e.message
+        end
+      end
     end
 
     def delete(*args, &block)
@@ -118,12 +151,22 @@ module Octopus
     end
 
     def transaction(options = {}, &block)
-      if !sharded && current_model_replicated?
-        run_queries_on_shard(Octopus.master_shard) do
+      begin
+        retries ||= 0
+        if !sharded && current_model_replicated?
+          run_queries_on_shard(Octopus.master_shard) do
+            select_connection.transaction(options, &block)
+          end
+        else
           select_connection.transaction(options, &block)
+      rescue ActiveRecord::StatementInvalid => e
+        if connection_bad(e.message)
+          Octopus.logger.error "Octopus.logger.error transaction: #{e.message}"
+          select_connection.verify!
+          retry if (retries += 1) < 3
+        else
+          raise e
         end
-      else
-        select_connection.transaction(options, &block)
       end
     end
 
@@ -207,28 +250,43 @@ module Octopus
 
     protected
 
+    def connection_bad(error)
+      error.include? "PG::ConnectionBad"
+    end
+
     # @thiagopradi - This legacy method missing logic will be keep for a while for compatibility
     # and will be removed when Octopus 1.0 will be released.
     # We are planning to migrate to a much stable logic for the Proxy that doesn't require method missing.
     def legacy_method_missing_logic(method, *args, &block)
-      if should_clean_connection_proxy?(method)
-        conn = select_connection
-        clean_connection_proxy
-        conn.send(method, *args, &block)
-      elsif should_send_queries_to_shard_slave_group?(method)
-        send_queries_to_shard_slave_group(method, *args, &block)
-      elsif should_send_queries_to_slave_group?(method)
-        send_queries_to_slave_group(method, *args, &block)
-      elsif should_send_queries_to_replicated_databases?(method)
-        send_queries_to_selected_slave(method, *args, &block)
-      else
-        val = select_connection.send(method, *args, &block)
+      begin
+        retries ||= 0
+        if should_clean_connection_proxy?(method)
+          conn = select_connection
+          clean_connection_proxy
+          conn.send(method, *args, &block)
+        elsif should_send_queries_to_shard_slave_group?(method)
+          send_queries_to_shard_slave_group(method, *args, &block)
+        elsif should_send_queries_to_slave_group?(method)
+          send_queries_to_slave_group(method, *args, &block)
+        elsif should_send_queries_to_replicated_databases?(method)
+          send_queries_to_selected_slave(method, *args, &block)
+        else
+          val = select_connection.send(method, *args, &block)
 
-        if val.instance_of? ActiveRecord::Result
-          val.current_shard = shard_name
+          if val.instance_of? ActiveRecord::Result
+            val.current_shard = shard_name
+          end
+
+          val
         end
-
-        val
+      rescue ActiveRecord::StatementInvalid => e
+        if connection_bad(e.message)
+          Octopus.logger.error "Octopus.logger.error legacy_method_missing_logic: #{e.message}"
+          select_connection.verify!
+          retry if (retries += 1) < 3
+        else
+          raise e
+        end
       end
     end
 

--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -80,7 +80,7 @@ module Octopus
           conn.verify!
           retry if (retries += 1) < 3
         else
-          raise e.message
+          raise e
         end
       end
     end


### PR DESCRIPTION
This is a known issue with octopus that is caused by trying
to switch between db connections. From what we can gather, during
the switch, the underlying database connections are not available
when the query is run. This code catches the "PG::ConnectionBad"
error and tries to run the #verify method to create the connections
to the database before retrying.

RESOURCES:
* https://github.com/thiagopradi/octopus/issues/457
* https://github.com/procore/octopus/commit/c015aacf60360e83738550dcbd1315d1cd383ae3